### PR TITLE
Modify pigaincorrect

### DIFF
--- a/xisscfpigaincorrect.sh
+++ b/xisscfpigaincorrect.sh
@@ -1,30 +1,14 @@
 #!/bin/bash
 
 ################################################################################
-## Redaction history
-################################################################################
-# Version | Date       | Author   | Description
-#-------------------------------------------------------------------------------
-# 1.0     | 2012.08.13 | yyoshida | prototype
-# 1.1     | 2012.08.21 | yyoshida | PI header������ʬ���ѹ�
-# 1.2     | 2012.11.23 | yyoshida | ftools��version�ѹ�,gain��������function���ѹ�
-# 2.0     | 2012.11.26 | yyoshida | C����Υץ�������bug����
-# 2.1     | 2012.11.27 | yyoshida | C����Υץ�������bug����
-# 3.0     | 2020.04.20 | yyoshida | redrawn
-
-
-################################################################################
 ## VARIABLES
 ################################################################################
 SCRIPTNAME=`basename $0`
-VERSION="3.0"
+VERSION="3.1"
 AUTHER="Y.Yoshida"
 LOG_LEVEL_CRITERIA=1 # initialize
 COMMAND_NOT_FOUND=0 # initialize
 ARGUMENT_NOT_FOUND=0 # initialize
-[ -L ${SCRIPTNAME} ] && SCRIPTNAME=$(readlink ${SCRIPTNAME})
-SYS=$(cd $(dirname ${SCRIPTNAME}); pwd)
-corrector=${SYS}/pigaincorrect
 
 
 ################################################################################
@@ -162,7 +146,7 @@ correct_pi_gain(){
     dump_pi_head fdump_head.dat
     prepare_data_ascii tmp_head.dat head.dat
 
-    ${corrector} data.dat data_cor.dat ${e_actual} ${e_expect}
+    pigaincorrect data.dat data_cor.dat ${e_actual} ${e_expect}
     rm -f data.dat
 }
 

--- a/xisscfpigaincorrect.sh
+++ b/xisscfpigaincorrect.sh
@@ -80,8 +80,6 @@ abort(){
         InvalidInputNumber) local message="Input is excess or deficiency !!" ;;        
         InvalidOption) local message="Invalid input option !!" ;;
         NotFoundCommand) local message="Not found necessary command !!" ;;
-        NotFoundDirectory) local message="Not found observation data directory !!" ;;
-        NotFoundEventDirectory) local message="Not found unscreened event directory !!" ;;
         *) local message="Abort !!" ;;
     esac
     logger 3 "${message}"
@@ -223,6 +221,11 @@ for var in input actual expect ;do
 done
 
 [ ${ARGUMENT_NOT_FOUND} -eq 1 ] && abort InvalidInputNumber
+
+if [ ! -e ${input} ];then
+    logger 3 "${input} is not found !!"
+    abort InvalidInput
+fi
 
 
 ##------------------------------------------------------------------------------


### PR DESCRIPTION
## `xisscfpigaincorrect.sh` の主な変更点

- `pigaincorrect`をスクリプト上で直接実行するように変更
    - このため、 `pigaincorrect` の PATH を通す必要がある。
- コマンドライン引数 `input` で指定したファイルの存在チェックを追加