### PR TITLE
modify pigaincorrect

### DIFF
--- a/xisscfpigaincorrect.sh
+++ b/xisscfpigaincorrect.sh
@@ -123,14 +123,6 @@ dump_pi_head(){
 }
 
 
-prepare_head_ascii(){
-    local datfile=$1
-    local outfile=$2
-    cat ${datfile}|sed '1,/count/d' > ${outfile}
-    rm -f ${datfile}
-}
-
-
 correct_pi_gain(){
     local pifile=$1
     local e_actual=$2
@@ -140,9 +132,8 @@ correct_pi_gain(){
     dump_pi_data fdump_data.dat
     prepare_data_ascii tmp_data.dat data.dat
 
-    prepare_dump_pi fdump_head.dat ${pifile} tmp_head.dat
+    prepare_dump_pi fdump_head.dat ${pifile} head.dat
     dump_pi_head fdump_head.dat
-    prepare_data_ascii tmp_head.dat head.dat
 
     pigaincorrect data.dat data_cor.dat ${e_actual} ${e_expect}
     rm -f data.dat

--- a/xisscfpigaincorrect.sh
+++ b/xisscfpigaincorrect.sh
@@ -123,6 +123,14 @@ dump_pi_head(){
 }
 
 
+prepare_head_ascii(){
+    local datfile=$1
+    local outfile=$2
+    cat ${datfile}|sed '1,/count/d' > ${outfile}
+    rm -f ${datfile}
+}
+
+
 correct_pi_gain(){
     local pifile=$1
     local e_actual=$2
@@ -132,8 +140,9 @@ correct_pi_gain(){
     dump_pi_data fdump_data.dat
     prepare_data_ascii tmp_data.dat data.dat
 
-    prepare_dump_pi fdump_head.dat ${pifile} head.dat
+    prepare_dump_pi fdump_head.dat ${pifile} tmp_head.dat
     dump_pi_head fdump_head.dat
+    prepare_data_ascii tmp_head.dat head.dat
 
     pigaincorrect data.dat data_cor.dat ${e_actual} ${e_expect}
     rm -f data.dat

--- a/xisscfpigaincorrect.sh
+++ b/xisscfpigaincorrect.sh
@@ -126,7 +126,7 @@ dump_pi_head(){
 prepare_head_ascii(){
     local datfile=$1
     local outfile=$2
-    cat ${datfile}|sed '1,/count/d' > ${outfile}
+    cat ${datfile}|sed '1,/EXTNAME/d' > ${outfile}
     rm -f ${datfile}
 }
 
@@ -142,7 +142,7 @@ correct_pi_gain(){
 
     prepare_dump_pi fdump_head.dat ${pifile} tmp_head.dat
     dump_pi_head fdump_head.dat
-    prepare_data_ascii tmp_head.dat head.dat
+    prepare_head_ascii tmp_head.dat head.dat
 
     pigaincorrect data.dat data_cor.dat ${e_actual} ${e_expect}
     rm -f data.dat

--- a/xisscfpigaincorrect.sh
+++ b/xisscfpigaincorrect.sh
@@ -105,6 +105,7 @@ dump_pi_data(){
     local script=$1
     fdump prhead=no clobber=yes < ${script} > /dev/null
     rm -f ${script}
+    punlearn fdump
 }
 
 
@@ -120,6 +121,7 @@ dump_pi_head(){
     local script=$1
     fdump prdata=no clobber=yes < ${script} > /dev/null
     rm -f ${script}
+    punlearn fdump
 }
 
 
@@ -159,6 +161,7 @@ create_corrected_pi(){
 
     fcreate cdf.dat data_cor.dat headfile=head.dat ${outfile} extname=SPECTRUM clobber=${clobber}
     rm -f cdf.dat data_cor.dat head.dat
+    punlearn fcreate
 }
 
 


### PR DESCRIPTION
### 背景

* inputで与えていたFITSファイルのheaderをoutputのFITSファイルのheaderにも利用する。
* しかし、必要十分な header を `fcreate` に与えられていなかった。

### 主な変更点

* 必要十分な header を `fcreate` ように生成するようにした。
* script 内で実行する FTOOLS ( `fdump`, `fcreate` ) の実行パラメータを `punlearn` でリセットするようにした。